### PR TITLE
Ping existing Clickhouse connections before sending OK. Otherwise try connecting again before sending CRITICAL

### DIFF
--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
 import pytest
+from clickhouse_driver.errors import Error, NetworkError
 
 from datadog_checks.clickhouse import ClickhouseCheck
 
@@ -37,10 +39,32 @@ def test_can_connect(aggregator, instance):
     (It used to be submitted only once on check init, which led to customer seeing "no data" in the UI.)
     """
     check = ClickhouseCheck('clickhouse', {}, [instance])
+
+    # Test for consecutive healthy clickhouse.can_connect statuses
     num_runs = 3
     for _ in range(num_runs):
         check.run()
-    aggregator.assert_service_check("clickhouse.can_connect", count=num_runs)
+    aggregator.assert_service_check("clickhouse.can_connect", count=num_runs, status=check.OK)
+    aggregator.reset()
+
+    # Test 1 healthy connection --> 2 Unhealthy service checks --> 1 healthy connection. Recovered
+    check.run()
+    with mock.patch('clickhouse_driver.Client', side_effect=NetworkError('Connection refused')):
+        with mock.patch('datadog_checks.clickhouse.ClickhouseCheck.ping_clickhouse', return_value=False):
+            check.run()
+            check.run()
+    check.run()
+    aggregator.assert_service_check("clickhouse.can_connect", count=2, status=check.CRITICAL)
+    aggregator.assert_service_check("clickhouse.can_connect", count=2, status=check.OK)
+    aggregator.reset()
+
+    # Test Exception in ping_clickhouse(), but reestablishes connection.
+    check.run()
+    with mock.patch('datadog_checks.clickhouse.ClickhouseCheck.ping_clickhouse', side_effect=Error()):
+        # connect() should be able to handle an exception in ping_clickhouse() and attempt reconnection
+        check.run()
+    check.run()
+    aggregator.assert_service_check("clickhouse.can_connect", count=3, status=check.OK)
 
 
 def test_custom_queries(aggregator, instance):


### PR DESCRIPTION
### What does this PR do?
Adds a check for an already established Clickhouse client connection for each `connect()` run. This act as both a more confident health check, and appropriately handles connection errors to either reestablish connection or send out a `CRITICAL` status. In Datadog Clickhouse version `1.3.1` the check continues to hold onto `self._client` even if the connection fails. This PR should fix that.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
When the Datadog Clickhouse integration version got bumped to `1.3.1`, I was excited to try out `clickhouse.can_connect` in order to monitor our Clickhouse connections as they are critical services. However, on testing, `clickhouse.can_connect` shows healthy, and even when I manually stop the `clickhouse-server` the `clickhouse.can_connect` check continued to submit healthy checks. This is definitely unexpected behavior and should be fixed. 
<!-- What inspired you to submit this pull request? -->

### Additional Notes
This should address some of the reconnect on error logic mentioned in 
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
